### PR TITLE
Add PHC25 platform placeholder files

### DIFF
--- a/phc25.h
+++ b/phc25.h
@@ -1,0 +1,30 @@
+#ifndef PHC25_H
+#define PHC25_H
+
+#include <stdint.h>
+
+/************************************************************/
+/* Thomson PHC-25 platform definitions                      */
+/*                                                          */
+/* TODO: Fill in real hardware addresses and color values.  */
+/************************************************************/
+
+/* Memory access macros (update addresses if needed) */
+#define POKE(addr, value) (*((volatile uint8_t *)(addr)) = (value))
+#define PEEK(addr) (*((volatile uint8_t *)(addr)))
+
+/* Basic color codes - placeholder values */
+#define black 0
+#define red 1
+#define green 2
+#define orange 3
+#define blue 4
+#define magenta 5
+#define cyan 6
+#define pink 7
+#define lgreen 10
+#define yellow 11
+#define lmagenta 13
+#define white 15
+
+#endif // PHC25_H

--- a/platform_phc25.c
+++ b/platform_phc25.c
@@ -1,0 +1,79 @@
+#include "platform.h"
+
+#ifdef PHC25
+
+/************************************************************/
+/* Display functions for Thomson PHC-25                     */
+/*                                                          */
+/* TODO: Implement these using the PHC-25 hardware specs.   */
+/************************************************************/
+
+void posxy(unsigned char column, unsigned char line)
+{
+    /* TODO: set cursor position */
+}
+
+void color(unsigned char foreground, unsigned char background)
+{
+    /* TODO: set foreground/background colors */
+}
+
+void prints(unsigned char x, unsigned char y, unsigned char *text)
+{
+    /* TODO: print a null terminated string at given coords */
+}
+
+void printsg(unsigned char x, unsigned char y, unsigned char *text)
+{
+    /* TODO: print string using graphic characters */
+}
+
+void printc(unsigned char x, unsigned char y, unsigned char c)
+{
+    /* TODO: print a single character at given coords */
+}
+
+void printcg(unsigned char x, unsigned char y, unsigned char c)
+{
+    /* TODO: print a graphic character at given coords */
+}
+
+uint8_t charatxy(uint8_t column, uint8_t line)
+{
+    /* TODO: return character at screen position */
+    return 0;
+}
+
+/************************************************************/
+/* Keyboard and clock                                       */
+/************************************************************/
+
+uint8_t scankey()
+{
+    /* TODO: scan keyboard matrix */
+    return 0;
+}
+
+void sleep(uint8_t seconds)
+{
+    /* TODO: busy-wait or use timer to sleep */
+}
+
+void ticks(uint8_t ticks)
+{
+    /* TODO: wait for given number of timer ticks */
+}
+
+uint8_t wait()
+{
+    /* TODO: wait for keypress or timeout based on timeout_ticks */
+    return 0;
+}
+
+uint8_t wait_key()
+{
+    /* TODO: wait until a key is pressed */
+    return 0;
+}
+
+#endif // PHC25


### PR DESCRIPTION
## Summary
- create `phc25.h` header with placeholder macros and color codes
- add `platform_phc25.c` with TODO implementations for Thomson PHC‑25

## Testing
- `make` *(fails: `/opt/cc68/lib/cc68: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6873ac3b91408327b93be63d24dcc4c3